### PR TITLE
Fix Xdump Option Builder wrap_in_quotes link problem

### DIFF
--- a/static/tools/xdump_option_builder.js
+++ b/static/tools/xdump_option_builder.js
@@ -1214,9 +1214,14 @@ function copyLinkToClipboard() {
 		if (inputElement.type == "checkbox") {
 			if (inputElement.checked) {
 				serializedForm += inputElement.id + "=1&";
-			} else if (inputElement.id == "event_systhrow" || inputElement.id.lastIndexOf("request_") == 0) {
-				// These specific checkboxes can be checked automatically if certain other
-				// options are checked, so if they're unchecked we need to make note.
+			} else if (
+				inputElement.id == "event_systhrow" ||
+				inputElement.id == "wrap_in_quotes" ||
+				inputElement.id.lastIndexOf("request_") == 0
+			) {
+				// These specific checkboxes are either checked by default, or can be
+				// checked automatically if certain other options are checked, so if
+				// they're unchecked we need to make note.
 				serializedForm += inputElement.id + "=0&";
 			}			
 		}


### PR DESCRIPTION
If the "Wrap in quotes (for use in a shell)" option is _unchecked_, its state is not preserved in URLs generated by the "Copy link" button - it will take the default value, which is _checked_.

This patch ensures that the "Wrap in quotes" option's state is preserved correctly.

Signed-off-by: Paul Cheeseman <paul.cheeseman@uk.ibm.com>