### PR TITLE
Xdump Option Builder: Disallow setting both file and data set patterns

### DIFF
--- a/static/tools/xdump_option_builder.js
+++ b/static/tools/xdump_option_builder.js
@@ -1007,7 +1007,7 @@ function buildAndUpdateResult() {
 	} else {
 		unsetErrorStyle(dumpFileTextElement);
 	}
-	
+
 	// SYSTDUMP data set name checks
 	var datasetTextElement = document.getElementById("dsn_text");
 	if (!datasetTextElement.disabled && datasetTextElement.value != "") {
@@ -1018,26 +1018,25 @@ function buildAndUpdateResult() {
 		} else {
 			unsetErrorStyle(datasetTextElement);
 		}
-		
-		if (dumpFileTextElement.value != "") {
-			var ok = false;
-			for (var i = 0; i < agentsThatDumpAFileIds.length; i++) {
-				if (agentsThatDumpAFileIds[i] != "agent_system" && document.getElementById(agentsThatDumpAFileIds[i]).checked) {
-					ok = true;
-				}				
-			}
-			if (!ok) {
-				resultIsGreen = false;
-				setErrorStyle(datasetTextElement);
-				setErrorStyle(dumpFileTextElement);
-				errorsHtml += "ERROR: File and data set patterns cannot both be specified when only system dumps are being generated.<br>";
-			}
-		}
 
 		if (containsReservedChars(datasetTextElement.value)) {
 			warningsHtml += "WARNING: Data set pattern contains a character that is disallowed on some platforms<br>";		
 		}		
 	} else {
+		unsetErrorStyle(datasetTextElement);
+	}
+	
+	// Check whether patterns have been specified for both dump filename and SYSTDUMP data set
+	if (
+		!dumpFileTextElement.disabled && dumpFileTextElement.value != "" &&
+		!datasetTextElement.disabled && datasetTextElement.value != ""
+	) {
+		resultIsGreen = false;
+		setErrorStyle(dumpFileTextElement);
+		setErrorStyle(datasetTextElement);
+		errorsHtml += "ERROR: File and data set patterns cannot both be specified in a single Xdump option. Please create a separate Xdump option for each dump type.<br>";
+	} else {
+		unsetErrorStyle(dumpFileTextElement);
 		unsetErrorStyle(datasetTextElement);
 	}
 


### PR DESCRIPTION
The Xdump Option Builder tool currently allows both the file (`file`) and data set (`dsn`) patterns to be set if system dumps and another dump type are enabled, which intuitively _seems_ like it should work, but the resulting option is rejected by the JVM.

In fact, it is never valid to specify both the file and data set patterns in a single Xdump option. If the user needs to specify both  patterns for different dump types, two separate Xdump options need to be created - i.e. one for each dump type.

This patch updates the error checking in this area accordingly.

Signed-off-by: Paul Cheeseman <paul.cheeseman@uk.ibm.com>