### PR TITLE
Fix Xtrace Option Builder trigger deserialization

### DIFF
--- a/static/tools/xtrace_option_builder.js
+++ b/static/tools/xtrace_option_builder.js
@@ -319,7 +319,7 @@ function parseTriggerParam(key, value) {
 					// id = URI encoded value
 					element.value = decodeURIComponent(triggerValue);
 				}
-				if (element.type == "radio") {
+				if (element.type == "number") {
 					// id = value
 					element.value = triggerValue;
 				}


### PR DESCRIPTION
When deserializing / reconstructing triggers from a copied link, the parameters in the URL for the **Delay** and **Limit** fields are currently not handled correctly, so their values are always set to zero.

The relevant code has blocks to handle `text` and `radio` type inputs, but nothing for `number` inputs. This is slightly odd because there are never any `radio` type elements in triggers, so I have simply changed this block to handle `number` inputs instead, which is what I suspect it was intended to do all along.

Signed-off-by: Paul Cheeseman <paul.cheeseman@uk.ibm.com>