### PR TITLE
Add user2 event to Xdump Option Builder

### DIFF
--- a/static/tools/xdump_option_builder.html
+++ b/static/tools/xdump_option_builder.html
@@ -106,6 +106,10 @@ ul {
 				<label for="event_user">User signal i.e. SIGQUIT ("kill -3") / SIGBREAK</label>
 			</li>
 			<li>
+				<input type="checkbox" id="event_user2"         name="event" value="user2"        data-hasfilter="false">
+				<label for="event_user2">User signal 2 i.e. SIGUSR2 ("kill -12") (Unix only)</label>
+			</li>
+			<li>
 				<input type="checkbox" id="event_gpf"          name="event" value="gpf"         data-hasfilter="false">
 				<label for="event_gpf">General Protection Fault (GPF) or unexpected SIGSEGV</label>
 			</li>

--- a/static/tools/xdump_option_builder.html
+++ b/static/tools/xdump_option_builder.html
@@ -106,8 +106,8 @@ ul {
 				<label for="event_user">User signal i.e. SIGQUIT ("kill -3") / SIGBREAK</label>
 			</li>
 			<li>
-				<input type="checkbox" id="event_user2"         name="event" value="user2"        data-hasfilter="false">
-				<label for="event_user2">User signal 2 i.e. SIGUSR2 ("kill -12") (Unix only)</label>
+				<input type="checkbox" id="event_user2"         name="event" value="user2"      data-hasfilter="false">
+				<label for="event_user2">User signal 2 i.e. SIGUSR2 (non-Windows only)</label>
 			</li>
 			<li>
 				<input type="checkbox" id="event_gpf"          name="event" value="gpf"         data-hasfilter="false">


### PR DESCRIPTION
This patch updates the Xdump Option Builder to include the new `user2` event which has been implemented in OpenJ9:

https://github.com/eclipse-openj9/openj9/issues/15636

Signed-off-by: Paul Cheeseman <paul.cheeseman@uk.ibm.com>