### PR TITLE
Xtrace Option Builder: Add count option

### DIFF
--- a/static/tools/xtrace_option_builder.html
+++ b/static/tools/xtrace_option_builder.html
@@ -40,6 +40,7 @@ button.add {
 }
 
 label {
+	display: inline-block;
 	vertical-align: middle;
 }
 
@@ -74,7 +75,6 @@ label[data-disabled=false] {
 
 td {
 	vertical-align: middle;
-	height: 20px">
 }
 
 ul {
@@ -186,10 +186,10 @@ The project website pages cannot be redistributed
 		<td>
 			<button type="button" class="add" id="button_add_trigger_group" title="Add group trigger">Group</button>
 		</td>
-		<td id="trace_initially_disabled_td">
+		<td id="trace_initially_disabled_td" title="Trace can be started with a trigger, e.g. when entering a specific method">
 			&nbsp;
-			<input type="checkbox" id="trace_initially_disabled" name="trace_initially_disabled" value="trace_initially_disabled" title="Trace can be started with a trigger, e.g. when entering a specific method">
-			<label for="trace_initially_disabled" title="Trace can be started with a trigger, e.g. when entering a specific method">Trace initially stopped</label>
+			<input type="checkbox" id="trace_initially_disabled" name="trace_initially_disabled" value="trace_initially_disabled">
+			<label for="trace_initially_disabled">Trace initially stopped</label>
 		</td>
 		<td title="Length of time to sleep for the &quot;thread sleep&quot; action">
 			&nbsp;


### PR DESCRIPTION
After working on a situation recently where the Xtrace `count` option proved useful, I realised that this option was not implemented in the Xtrace Option Builder. This commit addresses that omission.

More information on the `count` option:

https://www.eclipse.org/openj9/docs/xtrace/#count-tracepoint

Each tracepoint that's added to the tool will now have two new checkboxes - **Trace**, and **Count**:

![image](https://user-images.githubusercontent.com/32541517/192825654-5a6ba09c-ebed-4b1f-8422-4e46f00c9149.png)

This allows the user to choose whether they want to trace their chosen tracepoints, count the number of times they are hit, or both. The default is trace only, which matches the previous behaviour.

The patch is perhaps larger than expected due to the changes required for enabling/disabling elements appropriately, error checking updates, and updates to the link creation and parameter parsing code.

I also fixed some very minor layout issues that I encountered along the way.

Signed-off-by: Paul Cheeseman <paul.cheeseman@uk.ibm.com>