### PR TITLE
 Added the trademark symbol to Eclipse OpenJ9

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# OpenJ9 Development
+# Eclipse OpenJ9 Development
 
-The OpenJ9 website is built with [Gatsby.js](https://www.gatsbyjs.org/). See the Gatsby [quick start guide](https://www.gatsbyjs.org/docs/quick-start) for the basics.
+The Eclipse OpenJ9&trade; website is built with [Gatsby.js](https://www.gatsbyjs.org/). See the Gatsby [quick start guide](https://www.gatsbyjs.org/docs/quick-start) for the basics.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The project website pages cannot be redistributed
 # Eclipse OpenJ9 website
 
 
-This repository contains the source files for the [Eclipse OpenJ9 website](http://www.eclipse.org/openj9). The website uses the [React.js](https://reactjs.org/) javascript library and is built with the [Gatsby](https://www.gatsbyjs.org/) static-site generator.
+This repository contains the source files for the [Eclipse OpenJ9&trade; website](http://www.eclipse.org/openj9). The website uses the [React.js](https://reactjs.org/) javascript library and is built with the [Gatsby](https://www.gatsbyjs.org/) static-site generator.
 
 If you would like to contribute to the OpenJ9 project, please start by reading the general [Contribution guidelines](https://github.com/eclipse-openj9/openj9/blob/master/CONTRIBUTING.md) in the OpenJ9 repository. Information to help you contribute to the OpenJ9 website is covered in the [Contribution guidelines](CONTRIBUTING.md) in this repository.
 

--- a/benchmark/daytrader3.md
+++ b/benchmark/daytrader3.md
@@ -26,7 +26,7 @@ The project website pages cannot be redistributed
 
 ***Performance is not just throughput!***
 
-Many different metrics exist to measure the performance of an application including startup time, ramp up time, footprint, response time, as well as throughput. At Eclipse OpenJ9, we keep a watchful eye on all of these metrics, making sensible tradeoffs and providing tuning options that allow the JVM to be optimized for different workloads.
+Many different metrics exist to measure the performance of an application including startup time, ramp up time, footprint, response time, as well as throughput. At Eclipse OpenJ9&trade;, we keep a watchful eye on all of these metrics, making sensible tradeoffs and providing tuning options that allow the JVM to be optimized for different workloads.
 
 To showcase our performance pedigree we set about measuring the strengths of OpenJDK 9 with Eclipse OpenJ9 compared to an OpenJDK 9 with Hotspot. We chose the DayTrader 3 application because it is meaningful to measure different performance metrics, unlike many microbenchmarks that focus almost exclusively on throughput. The metrics we focused on include startup time, the JVM footprint size during the experiment, and of course, throughput.
 

--- a/benchmark/daytrader7.md
+++ b/benchmark/daytrader7.md
@@ -24,7 +24,7 @@ The project website pages cannot be redistributed
 
 # OpenJDK 8 performance with Eclipse OpenJ9
 
-**Benchmark testing demonstrates significantly better performance for OpenJDK 8 when using the Eclipse OpenJ9 VM, than with the Hotspot VM - just as for OpenJDK 9.**
+**Benchmark testing demonstrates significantly better performance for OpenJDK 8 when using the Eclipse OpenJ9&trade; VM, than with the Hotspot VM - just as for OpenJDK 9.**
 
 Many different metrics exist to measure the performance of an application including startup time, ramp up time, footprint, response time, as well as throughput. At Eclipse OpenJ9, we keep a watchful eye on all of these metrics, making sensible tradeoffs and providing tuning options that allow the virtual machine (VM) to be optimized for different workloads.
 

--- a/benchmark/openjdk11-daytrader7.md
+++ b/benchmark/openjdk11-daytrader7.md
@@ -1,6 +1,6 @@
 # OpenJDK 11 performance with Eclipse OpenJ9
 
-**Our benchmark results suggest that running an application on OpenJ9 instead of HotSpot delivers reductions in footprint and startup time without sacrificing throughput.**
+**Our benchmark results suggest that running an application on Eclipse OpenJ9&trade; instead of HotSpot delivers reductions in footprint and startup time without sacrificing throughput.**
 
 To evaluate the performance characteristics of OpenJ9 we used the DayTrader7 benchmark, which produced the following results:
 

--- a/benchmark/quarkus.md
+++ b/benchmark/quarkus.md
@@ -1,7 +1,7 @@
 # OpenJDK 11 performance on Quarkus with Eclipse OpenJ9
 
 
-**When we compared the results of running OpenJDK 11 on Quarkus with either the OpenJ9 VM or the HotSpot VM, OpenJ9 started faster with a smaller footprint.**
+**When we compared the results of running OpenJDK 11 on Quarkus with either the Eclipse OpenJ9&trade; VM or the HotSpot VM, OpenJ9 started faster with a smaller footprint.**
 
 We recorded the following results with the REST+CRUD benchmark application:
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -35,7 +35,7 @@ import Button from "../components/button";
 export default () => (
   <Layout isHome={false} title="The Eclipse OpenJ9 story" description="With a rich heritage, OpenJ9 has the credentials to deliver quality and reliability.">
     <section sx={{ backgroundColor: "#F5F9FC", paddingX: "7%", paddingY: "4rem" }}>
-      <Styled.h1 sx={{marginBottom:"3rem"}}>More about OpenJ9</Styled.h1>
+      <Styled.h1 sx={{marginBottom:"3rem"}}>More about Eclipse OpenJ9</Styled.h1>
       <div
         sx={{
           backgroundColor: "white",
@@ -46,7 +46,7 @@ export default () => (
       >
         <Styled.h2>Our story</Styled.h2>
         <Styled.p>
-          Eclipse OpenJ9 is a high performance, scalable, Java virtual machine (JVM) implementation that represents hundreds 
+          Eclipse OpenJ9&trade; is a high performance, scalable, Java virtual machine (JVM) implementation that represents hundreds 
           of person-years of effort. Contributed to the Eclipse project by IBM, the OpenJ9 JVM underpins the IBM SDK, Java 
           Technology Edition product that is a core component of many IBM Enterprise software products. Continued development 
           of OpenJ9 at the Eclipse foundation ensures wider collaboration, fresh innovation, and the opportunity to influence 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -89,7 +89,7 @@ export default () => (
         <Styled.h1>Unleash the power of Java</Styled.h1>
         <Styled.p>
           Optimized to run Java&trade; applications cost-effectively in the cloud, 
-          Eclipse OpenJ9 is a fast and efficient JVM that delivers power and performance when you need it most.
+          Eclipse OpenJ9&trade; is a fast and efficient JVM that delivers power and performance when you need it most.
         </Styled.p>
       </div>
     </section>

--- a/src/pages/news.js
+++ b/src/pages/news.js
@@ -34,7 +34,7 @@ export default ({data}) => {
   return(
   <Layout isHome={false} title="What's new with Eclipse OpenJ9" description="Find out what's in the latest release; Learn about the technology directly from our developers.">
     <section sx={{ backgroundColor: "#F5F9FC", paddingX: "7%", paddingTop:"4rem" }}>
-      <Styled.h1>What's new in the OpenJ9 project</Styled.h1>
+      <Styled.h1>What's new in the Eclipse OpenJ9 project</Styled.h1>
       <div
         sx={{
           paddingY: "2rem",
@@ -43,7 +43,7 @@ export default ({data}) => {
       >
         <Styled.p>
           Find out what's happening at the project. Read about the highlights of our latest release.
-          Catch the latest blog posts from our blog site; get top tips or deep dives about key features of OpenJ9 or simply read about experiences of working in the community.
+          Catch the latest blog posts from our blog site; get top tips or deep dives about key features of Eclipse OpenJ9&trade; or simply read about experiences of working in the community.
         </Styled.p>
       </div>
     </section>

--- a/src/pages/performance.js
+++ b/src/pages/performance.js
@@ -361,7 +361,7 @@ class performance extends Component {
         <Styled.h1 sx={{marginBottom:"1rem"}}>Performance Overview</Styled.h1>
           <Styled.p>
             Application performance can be measured using many different metrics, including startup time,
-            ramp-up time, footprint, and response time, as well as throughput. At Eclipse OpenJ9, we keep a watchful eye on all
+            ramp-up time, footprint, and response time, as well as throughput. At Eclipse OpenJ9&trade;, we keep a watchful eye on all
             of these metrics, making sensible tradeoffs and providing tuning options that allow the virtual machine (VM) to be
             optimized for different workloads. We regularly test and optimize OpenJ9 performance when running the most popular 
             Java frameworks such as Open Liberty, Quarkus, SpringBoot, and Micronaut. We're proud of our results. 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-website/issues/322

Added the trademark symbol to the first instance of Eclipse OpenJ9 in the website pages.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>