### PR TITLE
Update copyright year to 2023

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
- # Copyright (c) 2017, 2022 IBM Corp. and others
+ # Copyright (c) 2017, 2023 IBM Corp. and others
  #
  # This program and the accompanying materials are made available under
  # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@
  # OpenJDK Assembly Exception [2].
  #
  # [1] https://www.gnu.org/software/classpath/license.html
- # [2] http://openjdk.java.net/legal/assembly-exception.html
+ # [2] https://openjdk.org/legal/assembly-exception.html
  #
  # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  ###############################################################################

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corp. and others
+ * Copyright (c) 2017, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@
  * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
- * [2] http://openjdk.java.net/legal/assembly-exception.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@ Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
@@ -49,7 +49,7 @@ Also note that it can take a few minutes for the contents of the staging website
 ## OpenJ9 license information
 
 ```
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
  the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,7 @@ Exception [1] and GNU General Public License, version 2
 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ```

--- a/benchmark/daytrader3.md
+++ b/benchmark/daytrader3.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@ Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
@@ -196,7 +196,7 @@ To simulate a CPU constrained environment, the JVM process was pinned to a singl
 -Xscmx150M -Xscmaxaot120m -Xtune:virtualized
 ```
 
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 
 ---
 

--- a/benchmark/daytrader7.md
+++ b/benchmark/daytrader7.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@ Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/benchmark/server.xml
+++ b/benchmark/server.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@ Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/news-page-content/latestRelease.md
+++ b/news-page-content/latestRelease.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@ Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/components/card.js
+++ b/src/components/card.js
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/components/head.js
+++ b/src/components/head.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/components/mobileNav.js
+++ b/src/components/mobileNav.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/components/performanceCard.js
+++ b/src/components/performanceCard.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/components/testimonials.js
+++ b/src/components/testimonials.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/pages/news.js
+++ b/src/pages/news.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/pages/performance.js
+++ b/src/pages/performance.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022 IBM Corp. and others
+// Copyright (c) 2017, 2023 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 // OpenJDK Assembly Exception [2].
 
 // [1] https://www.gnu.org/software/classpath/license.html
-// [2] http://openjdk.java.net/legal/assembly-exception.html
+// [2] https://openjdk.org/legal/assembly-exception.html
 
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/static/tools/oj9_option_builder.css
+++ b/static/tools/oj9_option_builder.css
@@ -1,9 +1,9 @@
 /*
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2]. 
 [1] https://www.gnu.org/software/classpath/license.html  
-[2] http://openjdk.java.net/legal/assembly-exception.html 
+[2] https://openjdk.org/legal/assembly-exception.html
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  The project website pages cannot be redistributed 
  */

--- a/static/tools/xdump_option_builder.html
+++ b/static/tools/xdump_option_builder.html
@@ -6,11 +6,11 @@ TODO:
 
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2]. 
 [1] https://www.gnu.org/software/classpath/license.html  
-[2] http://openjdk.java.net/legal/assembly-exception.html 
+[2] https://openjdk.org/legal/assembly-exception.html
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 The project website pages cannot be redistributed
 -->

--- a/static/tools/xtrace_option_builder.html
+++ b/static/tools/xtrace_option_builder.html
@@ -7,11 +7,11 @@ TODO:
 
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2].
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 The project website pages cannot be redistributed
 -->
@@ -101,11 +101,11 @@ a.remove {
 <link rel="stylesheet" type="text/css" href="oj9_option_builder.css">
 
 <!--
-Copyright (c) 2017, 2022 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2].
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 The project website pages cannot be redistributed
 -->


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-website/issues/327

Changed the copyright dates to 2017, 2023. Updated references to openjdk.java.net.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>