### PR TITLE
Updated website release note 0.37.0

### DIFF
--- a/news-page-content/latestRelease.md
+++ b/news-page-content/latestRelease.md
@@ -22,24 +22,23 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 The project website pages cannot be redistributed
 -->
 
-### Eclipse OpenJ9 version 0.36.x released
+### Eclipse OpenJ9 version 0.37.0 released
 
-February 2023
+April 2023
  
-We're pleased to announce the availability of Eclipse OpenJ9&trade; v0.36.x.
+We're pleased to announce the availability of Eclipse OpenJ9&trade; v0.37.0.
  
-OpenJ9 release 0.36.0 supports OpenJDK version 8 and 17. Release 0.36.1 supports OpenJDK 11. 
-
-For more information about supported platforms and OpenJDK versions,
+This release works with OpenJDK version 19. OpenJDK 19 is out of support at the time of the 0.37.0 release. Builds of 0.37.0 should not be used in production and might contain known security vulnerabilities as of 18 April 2023. For more information about supported platforms and OpenJDK versions,
 see [Supported environments](https://www.eclipse.org/openj9/docs/openj9_support/).
 
 Other updates in this release include the following:
-
-- On operating systems other than Windows&trade; and z/OS&reg;, the default shared classes cache directory in the user's home directory is changed from `javasharedresources` to `.cache/javasharedresources`.
-- New `-XX:[+|-]MergeCompilerOptions` option is added to enable or disable the merging of multiple `-Xjit` or `-Xaot` options into a single `-Xjit` or `-Xaot` option.
-- If a client JVM does not indicate a specific JITServer AOT cache it wants to use with the `-XX:JITServerAOTCacheName=<cache_name>` option, the `default` JITServer AOT cache is used instead of a nameless cache.
-- New `-XX:JITServerAOTmx` option is added to specify the maximum amount of memory that all AOT cache instances combined can use at the JITServer server.
-- New `-XX:[+|-]JITServerAOTCachePersistence` option is added to specify whether the JITServer server periodically saves its AOT caches to files. Other JITServer instances can then load these caches the first time that a client requests a particular cache.
-- New `-XX:JITServerAOTCacheDir` option is added to specify the directory for saving or loading the JITServer AOT cache files.
+ 
+- Linux&reg; builds for platforms Linux x86 64-bit, Linux on POWER&reg; LE 64-bit, and Linux on IBM Z&reg; 64-bit now use gcc 11.2 instead of gcc 10.3. Linux AArch64 64-bit continues to use the gcc 10.3 compiler.
+- The OpenJ9 ThreadMXBean interface extends the [com.sun.management.ThreadMXBean](https://docs.oracle.com/javase/8/docs/jre/api/management/extension/com/sun/management/ThreadMXBean.html) interface instead of the java.lang.management.ThreadMXBean interface.
+- OpenJ9 now supports the use of an extra attribute, `tokenlabel`, in the SunPKCS11 configuration file on z/OS&reg; and Linux on IBM Z to assign a label to a PKCS#11 token. The `tokenlabel` attribute can be used instead of the `slot` or `slotListIndex` attributes.
 
 To read more about these and other changes, see the [OpenJ9 user documentation](https://www.eclipse.org/openj9/docs/openj9_releases/).
+ 
+#### Performance highlights include:
+ 
+-  With the implementation of CRC-32C polynomial acceleration on Linux on POWER LE (ppc64le) and AIX POWER&reg; BE (ppc64), performance of CRC-32C calculations on these platforms is 25 times faster (even up to 42 times faster) on data payload of typical sizes.


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-website/issues/343

Updated the website release note 0.37.0

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>