### PR TITLE
Update copyright year to 2024

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
- # Copyright (c) 2017, 2023 IBM Corp. and others
+ # Copyright (c) 2017, 2024 IBM Corp. and others
  #
  # This program and the accompanying materials are made available under
  # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corp. and others
+ * Copyright (c) 2017, 2024 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ Also note that it can take a few minutes for the contents of the staging website
 ## OpenJ9 license information
 
 ```
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 
 This program and the accompanying materials are made available under
  the terms of the Eclipse Public License 2.0 which accompanies this

--- a/benchmark/daytrader3.md
+++ b/benchmark/daytrader3.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -196,7 +196,7 @@ To simulate a CPU constrained environment, the JVM process was pinned to a singl
 -Xscmx150M -Xscmaxaot120m -Xtune:virtualized
 ```
 
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 
 ---
 

--- a/benchmark/daytrader7.md
+++ b/benchmark/daytrader7.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this

--- a/benchmark/server.xml
+++ b/benchmark/server.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/news-page-content/latestRelease.md
+++ b/news-page-content/latestRelease.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/components/card.js
+++ b/src/components/card.js
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/components/head.js
+++ b/src/components/head.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/components/mobileNav.js
+++ b/src/components/mobileNav.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/components/performanceCard.js
+++ b/src/components/performanceCard.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/components/testimonials.js
+++ b/src/components/testimonials.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/pages/news.js
+++ b/src/pages/news.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/pages/performance.js
+++ b/src/pages/performance.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2023 IBM Corp. and others
+// Copyright (c) 2017, 2024 IBM Corp. and others
 
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this

--- a/static/tools/oj9_option_builder.css
+++ b/static/tools/oj9_option_builder.css
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2]. 
 [1] https://www.gnu.org/software/classpath/license.html  

--- a/static/tools/xdump_option_builder.html
+++ b/static/tools/xdump_option_builder.html
@@ -6,7 +6,7 @@ TODO:
 
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0. 
 This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2]. 
 [1] https://www.gnu.org/software/classpath/license.html  

--- a/static/tools/xtrace_option_builder.html
+++ b/static/tools/xtrace_option_builder.html
@@ -7,7 +7,7 @@ TODO:
 
 <!DOCTYPE html>
 <!--
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2].
 [1] https://www.gnu.org/software/classpath/license.html
@@ -101,7 +101,7 @@ a.remove {
 <link rel="stylesheet" type="text/css" href="oj9_option_builder.css">
 
 <!--
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2024 IBM Corp. and others
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2].
 [1] https://www.gnu.org/software/classpath/license.html


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-website/issues/360

Changed the copyright dates to 2017, 2024.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>